### PR TITLE
Increase iteration limit to support deeper nested groups per default

### DIFF
--- a/src/GitLabPages/Impl/JobContextResolver.cs
+++ b/src/GitLabPages/Impl/JobContextResolver.cs
@@ -41,7 +41,7 @@ namespace GitLabPages.Impl
             var currentIndex = 1;
             var current = "/";
             var currentIteraton = 0;
-            var maxIterations = 2;
+            var maxIterations = 3;
             if (_options.AdditionalParentGroups > 0)
             {
                 maxIterations += _options.AdditionalParentGroups;


### PR DESCRIPTION
In my environment it is common to have paths like dev/project/service
without this patch the service repository would not be reachable without
listing each of them in the configuration.